### PR TITLE
Added Numberpad-Support

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -158,21 +158,35 @@ void initLayout()
 
 	// same for all layouts
 	wcscpy(mappingTableLevel1 +  2, L"1234567890-`");
+	wcscpy(mappingTableLevel1 + 71, L"789-456+1230.");
+	mappingTableLevel1[69] = 0x0009; // tabulator (not sure about this one)
 
 	wcscpy(mappingTableLevel2 + 41, L"̌");  // key to the left of the "1" key
 	wcscpy(mappingTableLevel2 +  2, L"°§ℓ»«$€„“”—̧");
+	wcscpy(mappingTableLevel2 + 71, L"✔✘†-♣€‣+♦♥♠␣."); // numeric keypad
+	mappingTableLevel2[69] = 0x0009; // tabulator (not sure about this one)
+	// https://neo-layout.org/grafik/aufsteller/neo20-aufsteller.pdf
 
 	wcscpy(mappingTableLevel3 + 41, L"^");
 	wcscpy(mappingTableLevel3 +  2, L"¹²³›‹¢¥‚‘’—̊");
 	wcscpy(mappingTableLevel3 + 16, L"…_[]^!<>=&ſ̷");
 	wcscpy(mappingTableLevel3 + 30, L"\\/{}*?()-:@");
 	wcscpy(mappingTableLevel3 + 44, L"#$|~`+%\"';");
+	wcscpy(mappingTableLevel3 + 71, L"↕↑↨−←:→±↔↓⇌%,"); // numeric keypad
+	wcscpy(mappingTableLevel3 + 53, L"÷");  // /-key on numeric keypad
+	wcscpy(mappingTableLevel3 + 55, L"⋅");  // *-key on numeric keypad
+	wcscpy(mappingTableLevel3 + 69, L"=");  // num-lock-key
 
 	wcscpy(mappingTableLevel4 + 41, L"̇");
 	wcscpy(mappingTableLevel4 +  2, L"ªº№⋮·£¤0/*-¨");
 	wcscpy(mappingTableLevel4 + 21, L"¡789+−˝");
 	wcscpy(mappingTableLevel4 + 35, L"¿456,.");
 	wcscpy(mappingTableLevel4 + 49, L":123;");
+	wcscpy(mappingTableLevel4 + 53, L"∕");  // /-key on numeric keypad
+	wcscpy(mappingTableLevel4 + 55, L"×");  // *-key on numeric keypad
+	wcscpy(mappingTableLevel4 + 74, L"∖");  // --key on numeric keypad
+	wcscpy(mappingTableLevel4 + 78, L"∓");  // +-key on numeric keypad
+	wcscpy(mappingTableLevel4 + 69, L"≠");  // num-lock-key
 
 	// layout dependent
 	if (strcmp(layout, "adnw") == 0) {
@@ -249,10 +263,21 @@ void initLayout()
 		wcscpy(mappingTableLevel5 +  2, L"₁₂₃♂♀⚥ϰ⟨⟩₀?῾");
 		wcscpy(mappingTableLevel5 + 27, L"᾿");
 		mappingTableLevel5[57] = 0x00a0;  // space = no-break space
+		wcscpy(mappingTableLevel5 + 71, L"≪∩≫⊖⊂⊶⊃⊕≤∪≥‰′"); // numeric keypad
+
+		wcscpy(mappingTableLevel5 + 53, L"⌀");  // /-key on numeric keypad
+		wcscpy(mappingTableLevel5 + 55, L"⊙");  // *-key on numeric keypad
+		wcscpy(mappingTableLevel5 + 69, L"≈");  // num-lock-key
+
 		wcscpy(mappingTableLevel6 + 41, L"̣");
 		wcscpy(mappingTableLevel6 +  2, L"¬∨∧⊥∡∥→∞∝⌀?̄");
 		wcscpy(mappingTableLevel6 + 27, L"˘");
 		mappingTableLevel6[57] = 0x202f;  // space = narrow no-break space
+		wcscpy(mappingTableLevel6 + 71, L"⌈⋂⌉∸⊆⊷⊇∔⌊⋃⌋□"); // numeric keypad
+		mappingTableLevel6[83] = 0x02dd; // double acute accent (not sure about this one)
+		wcscpy(mappingTableLevel6 + 53, L"∣");  // /-key on numeric keypad
+		wcscpy(mappingTableLevel6 + 55, L"⊗");  // *-key on numeric keypad
+		wcscpy(mappingTableLevel6 + 69, L"≡");  // num-lock-key
 	}
 
 	// if quote/ä is the right level 3 modifier, copy symbol of quote/ä key to backslash/# key
@@ -459,6 +484,19 @@ bool handleLayer4SpecialCases(KBDLLHOOKSTRUCT keyInfo)
 	}
 	mappingTable[57] = '0';
 
+	// numeric keypad
+	mappingTable[71] = VK_HOME;
+	mappingTable[72] = VK_UP;
+	mappingTable[73] = VK_PRIOR;
+	mappingTable[75] = VK_LEFT;
+	mappingTable[76] = VK_ESCAPE; // not sure about this one
+	mappingTable[77] = VK_RIGHT;
+	mappingTable[79] = VK_END;
+	mappingTable[80] = VK_DOWN;
+	mappingTable[81] = VK_NEXT;
+	mappingTable[82] = VK_INSERT;
+	mappingTable[83] = VK_DELETE;
+
 	if (mappingTable[keyInfo.scanCode] != 0) {
 //		if (mappingTable[keyInfo.scanCode] == VK_RETURN)
 //			bScan = 0x1c;
@@ -614,8 +652,8 @@ LRESULT CALLBACK keyevent(int code, WPARAM wparam, LPARAM lparam)
 	}
 
 	if (code == HC_ACTION && wparam == WM_KEYDOWN &&
-		shiftPressed && keyInfo.scanCode == 69) {
-		// Shift + Pause
+		shiftPressed && keyInfo.scanCode == 70) {
+		// Shift + ScrollLock
 		toggleBypassMode();
 		return -1;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,7 @@
 #define UNICODE
 /**
  * Alternative Windows driver for the Neo2 based keyboard layouts:
- * Neo2, (www.neo-layout.org)
+ * Neo2, (https://www.neo-layout.org)
  * AdNW, AdNWzjßf, KOY (www.adnw.de)
  * bone (https://web.archive.org/web/20180721192908/http://wiki.neo-layout.org/wiki/Bone)
  * qwertz (https://de.wikipedia.org/wiki/QWERTZ-Tastaturbelegung)

--- a/src/main.c
+++ b/src/main.c
@@ -925,7 +925,6 @@ LRESULT CALLBACK keyevent(int code, WPARAM wparam, LPARAM lparam)
 
 	// Shift + Pause
 	if (code == HC_ACTION && wparam == WM_KEYDOWN && keyInfo.vkCode == VK_PAUSE && modState.shift) {
-
 		toggleBypassMode();
 		return -1;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -185,6 +185,19 @@ void initLevel4SpecialCases() {
 	}
 
 	mappingTableLevel4Special[57] = '0';
+
+	// numeric keypad
+	mappingTableLevel4Special[71] = VK_HOME;
+	mappingTableLevel4Special[72] = VK_UP;
+	mappingTableLevel4Special[73] = VK_PRIOR;
+	mappingTableLevel4Special[75] = VK_LEFT;
+	mappingTableLevel4Special[76] = VK_ESCAPE; // not sure about this one
+	mappingTableLevel4Special[77] = VK_RIGHT;
+	mappingTableLevel4Special[79] = VK_END;
+	mappingTableLevel4Special[80] = VK_DOWN;
+	mappingTableLevel4Special[81] = VK_NEXT;
+	mappingTableLevel4Special[82] = VK_INSERT;
+	mappingTableLevel4Special[83] = VK_DELETE;
 }
 
 void initLayout()
@@ -546,72 +559,6 @@ bool handleLayer4SpecialCases(KBDLLHOOKSTRUCT keyInfo)
 		// extended flag (bit 0) is necessary for selecting text with shift + arrow
 		keybd_event(mappingTableLevel4Special[keyInfo.scanCode], bScan, dwFlagsFromKeyInfo(keyInfo) | KEYEVENTF_EXTENDEDKEY, 0);
 
-	mappingTable[16] = VK_PRIOR;
-	if (strcmp(layout, "kou") == 0 || strcmp(layout, "vou") == 0) {
-		mappingTable[17] = VK_NEXT;
-		mappingTable[18] = VK_UP;
-		mappingTable[19] = VK_BACK;
-		mappingTable[20] = VK_DELETE;
-	} else {
-		mappingTable[17] = VK_BACK;
-		mappingTable[18] = VK_UP;
-		mappingTable[19] = VK_DELETE;
-		mappingTable[20] = VK_NEXT;
-	}
-	mappingTable[30] = VK_HOME;
-	mappingTable[31] = VK_LEFT;
-	mappingTable[32] = VK_DOWN;
-	mappingTable[33] = VK_RIGHT;
-	mappingTable[34] = VK_END;
-	if (strcmp(layout, "kou") == 0 || strcmp(layout, "vou") == 0) {
-		mappingTable[44] = VK_INSERT;
-		mappingTable[45] = VK_TAB;
-		mappingTable[46] = VK_RETURN;
-		mappingTable[47] = VK_ESCAPE;
-	} else {
-		mappingTable[44] = VK_ESCAPE;
-		mappingTable[45] = VK_TAB;
-		mappingTable[46] = VK_INSERT;
-		mappingTable[47] = VK_RETURN;
-	}
-	mappingTable[57] = '0';
-
-	// numeric keypad
-	mappingTable[71] = VK_HOME;
-	mappingTable[72] = VK_UP;
-	mappingTable[73] = VK_PRIOR;
-	mappingTable[75] = VK_LEFT;
-	mappingTable[76] = VK_ESCAPE; // not sure about this one
-	mappingTable[77] = VK_RIGHT;
-	mappingTable[79] = VK_END;
-	mappingTable[80] = VK_DOWN;
-	mappingTable[81] = VK_NEXT;
-	mappingTable[82] = VK_INSERT;
-	mappingTable[83] = VK_DELETE;
-
-	if (mappingTable[keyInfo.scanCode] != 0) {
-//		if (mappingTable[keyInfo.scanCode] == VK_RETURN)
-//			bScan = 0x1c;
-//		else if (mappingTable[keyInfo.scanCode] == VK_INSERT)
-//			bScan = 0x52;  // or 0x52e0?
-		// If arrow key, page up/down, home or end,
-		// send flag 0x01 (bit 0 = extended).
-		// This in necessary for selecting text with shift + arrow.
-//		if (mappingTable[keyInfo.scanCode]==VK_LEFT
-//			|| mappingTable[keyInfo.scanCode]==VK_RIGHT
-//			|| mappingTable[keyInfo.scanCode]==VK_UP
-//			|| mappingTable[keyInfo.scanCode]==VK_DOWN
-//			|| mappingTable[keyInfo.scanCode]==VK_PRIOR
-//			|| mappingTable[keyInfo.scanCode]==VK_NEXT
-//			|| mappingTable[keyInfo.scanCode]==VK_HOME
-//			|| mappingTable[keyInfo.scanCode]==VK_END
-//			|| mappingTable[keyInfo.scanCode]==VK_INSERT
-//			|| mappingTable[keyInfo.scanCode]==VK_RETURN)
-			// always send extended flag (maybe this fixes mousepad issues)
-			keybd_event(mappingTable[keyInfo.scanCode], 0, 0x01, 0);
-//		else
-//			keybd_event(mappingTable[keyInfo.scanCode], bScan, 0, 0);
-
 		return true;
 	}
 	return false;
@@ -935,8 +882,6 @@ bool updateStatesAndWriteKey(KBDLLHOOKSTRUCT keyInfo, bool isKeyUp)
 		return false;
 	} else if (level == 4 && handleLayer4SpecialCases(keyInfo)) {
 		return false;
-	} else if (keyInfo.vkCode >= 0x60 && keyInfo.vkCode <= 0x6F) {
-		// Numeric keypad -> don't remap
 	} else if (level == 1 && keyInfo.vkCode >= 0x30 && keyInfo.vkCode <= 0x39) {
 		// numbers 0 to 9 -> don't remap
 	} else if (!(qwertzForShortcuts && isSystemKeyPressed())) {

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -4,7 +4,7 @@ layout=neo
 
 # use quote/ä as right level 3 modifier
 # ä-Taste als rechten Ebene3-Modifier verwenden
-symmetricalLevel3Modifiers=0
+symmetricalLevel3Modifiers=1
 
 # use Return as right level 3 modifier
 # Enter-Taste als rechten Ebene3-Modifier verwenden
@@ -16,7 +16,7 @@ tabKeyAsMod4L=0
 
 # enable caps lock (activate by pressing both shift keys)
 # Caps-Lock verwenden (aktivieren mit beiden Shift-Tasten gleichzeitig)
-capsLockEnabled=0
+capsLockEnabled=1
 
 # enable shift lock (activate by pressing both shift keys)
 # Shift-Lock verwenden (aktivieren mit beiden Shift-Tasten gleichzeitig)
@@ -41,7 +41,7 @@ swapLeftCtrlLeftAltAndLeftWin=0
 
 # support levels 5 and 6 (experimental)
 # Unterstützung der Ebenen 5 und 6 (experimentell)
-supportLevels5and6=0
+supportLevels5and6=1	
 
 # CapsLock key acts as Escape when hit alone (experimental)
 # CapsLock-Taste sendet Escape, wenn sie alleine angeschlagen wird (experimentell)
@@ -58,4 +58,4 @@ mod4LAsTab=0
 # show debug output in a separate console window
 # Debug-Ausgabe in einem separaten Konsolen-Fenster anzeigen
 # (wenn neo-llkh.exe in der Git Bash gestartet wird, sollte dieser Wert auf 0 gesetzt werden)
-debugWindow=0
+debugWindow=1

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -58,4 +58,4 @@ mod4LAsTab=0
 # show debug output in a separate console window
 # Debug-Ausgabe in einem separaten Konsolen-Fenster anzeigen
 # (wenn neo-llkh.exe in der Git Bash gestartet wird, sollte dieser Wert auf 0 gesetzt werden)
-debugWindow=1
+debugWindow=0

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -41,7 +41,7 @@ swapLeftCtrlLeftAltAndLeftWin=0
 
 # support levels 5 and 6 (experimental)
 # Unterstützung der Ebenen 5 und 6 (experimentell)
-supportLevels5and6=0
+supportLevels5and6=1	
 
 # CapsLock key acts as Escape when hit alone (experimental)
 # CapsLock-Taste sendet Escape, wenn sie alleine angeschlagen wird (experimentell)


### PR DESCRIPTION
Added Numberpad-Support for level 2-6.
Changed shortcut for toggling bypass-mode from <kbd>Shift</kbd> + <kbd>Pause</kbd> to <kbd>Shift</kbd> + <kbd>Scroll Lock</kbd> (because keycode 69 was the keycode for <kbd>Pause</kbd> and <kbd>Num Lock</kbd>)

Known Bugs:
- Strangely enough the middle row (456) don't work.
- The € for <kbd>Shift</kbd> + <kbd>5</kbd> only works when numberLock is activated.
- The operator characters print the same boring characters in every level. e.g.  <kbd>Mod4</kbd> + <kbd>+</kbd> ≠ ∓ (it should though)
- There is a bidirectional relationship between the numberkeys and the non-printing control keys. So the arrow key and so on produce numbers. Why??

Unknown Bugs:
- Probably some more

-------------------------------
Would be very thankful if a Pro can look at the code and fix the bugs.
Issue #11 is not solved in this branch but the shortcut now uses the even lesser used scroll-lock