### PR TITLE
Bugfix/fix bypass mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -656,7 +656,7 @@ LRESULT CALLBACK keyevent(int code, WPARAM wparam, LPARAM lparam)
 		}
 	}
 
-	if (code == HC_ACTION && wparam == WM_KEYDOWN && keyInfo.scanCode == 69 && shiftPressed) {
+	if (code == HC_ACTION && wparam == WM_KEYDOWN && keyInfo.vkCode == VK_PAUSE && shiftPressed) {
 		// Shift + Pause
 		toggleBypassMode();
 		return -1;


### PR DESCRIPTION
Fix bypass mode:
* Check virtual key code instead of scan code because pause key and NumLock have the same scan code.
* Observe the state of shift keys also in bypass mode because otherwise bypass mode can be stopped without pressing shift.

Fix issue #11 