### PR TITLE
Added `keyUp` events & `CapsLock` synchronization; refactored handling of events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.o
 *.bak
 src/neo-llkh.exe
+src/main.exe
+.vscode
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,5 +18,5 @@ neo-llkh.exe: $(OBJECTS)
 %.o: %.rc
 	$(WINDRES) -i $^ -o $@
 
-clean: 
+clean:
 	@rm -f $(OBJECTS) neo-llkh.exe

--- a/src/main.c
+++ b/src/main.c
@@ -731,6 +731,7 @@ void handleMod3Key(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKe
 				// release Mod3_R
 				keybd_event(keyInfo.vkCode, 0, KEYEVENTF_KEYUP, 0);
 				// send Return
+				keybd_event(VK_RETURN, 0, KEYEVENTF_EXTENDEDKEY, 0);
 				keybd_event(VK_RETURN, 0, KEYEVENTF_KEYUP | KEYEVENTF_EXTENDEDKEY, 0);
 				level3modRightAndNoOtherKeyPressed = false;
 				return;
@@ -742,6 +743,7 @@ void handleMod3Key(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKe
 				// release CapsLock/Mod3_L
 				keybd_event(VK_CAPITAL, 0, KEYEVENTF_KEYUP, 0);
 				// send Escape
+				keybd_event(VK_ESCAPE, 0, KEYEVENTF_EXTENDEDKEY, 0);
 				keybd_event(VK_ESCAPE, 0, KEYEVENTF_KEYUP | KEYEVENTF_EXTENDEDKEY, 0);
 				level3modLeftAndNoOtherKeyPressed = false;
 				return;
@@ -772,7 +774,9 @@ void handleMod4Key(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKe
 				printf("Level4 lock %s!\n", level4LockActive ? "activated" : "deactivated");
 			} else if (mod4LAsTab && level4modLeftAndNoOtherKeyPressed) {
 				keybd_event(keyInfo.vkCode, 0, KEYEVENTF_KEYUP, 0); // release Mod4_L
-				keybd_event(VK_TAB, 0, KEYEVENTF_KEYUP | KEYEVENTF_EXTENDEDKEY, 0); // send Tab
+				keybd_event(VK_TAB, 0, KEYEVENTF_EXTENDEDKEY, 0); // send Tab down
+				keybd_event(VK_TAB, 0, KEYEVENTF_KEYUP | KEYEVENTF_EXTENDEDKEY, 0); // send Tab up
+
 				level4modLeftAndNoOtherKeyPressed = false;
 				modState->mod4 = level4modLeftPressed | level4modRightPressed;
 				return;

--- a/src/main.c
+++ b/src/main.c
@@ -146,6 +146,45 @@ void mapLevels_2_5_6(TCHAR * mappingTableOutput, TCHAR * newChars)
 	}
 }
 
+void initLevel4SpecialCases() {
+	for (int i = 0; i < LEN; i++)
+		mappingTableLevel4Special[i] = 0;
+
+	mappingTableLevel4Special[16] = VK_PRIOR;
+
+	if (strcmp(layout, "kou") == 0 || strcmp(layout, "vou") == 0) {
+		mappingTableLevel4Special[17] = VK_NEXT;
+		mappingTableLevel4Special[18] = VK_UP;
+		mappingTableLevel4Special[19] = VK_BACK;
+		mappingTableLevel4Special[20] = VK_DELETE;
+	} else {
+		mappingTableLevel4Special[17] = VK_BACK;
+		mappingTableLevel4Special[18] = VK_UP;
+		mappingTableLevel4Special[19] = VK_DELETE;
+		mappingTableLevel4Special[20] = VK_NEXT;
+	}
+
+	mappingTableLevel4Special[30] = VK_HOME;
+	mappingTableLevel4Special[31] = VK_LEFT;
+	mappingTableLevel4Special[32] = VK_DOWN;
+	mappingTableLevel4Special[33] = VK_RIGHT;
+	mappingTableLevel4Special[34] = VK_END;
+
+	if (strcmp(layout, "kou") == 0 || strcmp(layout, "vou") == 0) {
+		mappingTableLevel4Special[44] = VK_INSERT;
+		mappingTableLevel4Special[45] = VK_TAB;
+		mappingTableLevel4Special[46] = VK_RETURN;
+		mappingTableLevel4Special[47] = VK_ESCAPE;
+	} else {
+		mappingTableLevel4Special[44] = VK_ESCAPE;
+		mappingTableLevel4Special[45] = VK_TAB;
+		mappingTableLevel4Special[46] = VK_INSERT;
+		mappingTableLevel4Special[47] = VK_RETURN;
+	}
+
+	mappingTableLevel4Special[57] = '0';
+}
+
 void initLayout()
 {
 	// initialize the mapping tables
@@ -274,44 +313,7 @@ void initLayout()
 	mappingTableLevel2[8] = 0x20AC;  // €
 
 	// level4 special cases
-	for (int i = 0; i < LEN; i++)
-		mappingTableLevel4Special[i] = 0;
-
-	mappingTableLevel4Special[16] = VK_PRIOR;
-	if (strcmp(layout, "kou") == 0 || strcmp(layout, "vou") == 0)
-	{
-		mappingTableLevel4Special[17] = VK_NEXT;
-		mappingTableLevel4Special[18] = VK_UP;
-		mappingTableLevel4Special[19] = VK_BACK;
-		mappingTableLevel4Special[20] = VK_DELETE;
-	}
-	else
-	{
-		mappingTableLevel4Special[17] = VK_BACK;
-		mappingTableLevel4Special[18] = VK_UP;
-		mappingTableLevel4Special[19] = VK_DELETE;
-		mappingTableLevel4Special[20] = VK_NEXT;
-	}
-	mappingTableLevel4Special[30] = VK_HOME;
-	mappingTableLevel4Special[31] = VK_LEFT;
-	mappingTableLevel4Special[32] = VK_DOWN;
-	mappingTableLevel4Special[33] = VK_RIGHT;
-	mappingTableLevel4Special[34] = VK_END;
-	if (strcmp(layout, "kou") == 0 || strcmp(layout, "vou") == 0)
-	{
-		mappingTableLevel4Special[44] = VK_INSERT;
-		mappingTableLevel4Special[45] = VK_TAB;
-		mappingTableLevel4Special[46] = VK_RETURN;
-		mappingTableLevel4Special[47] = VK_ESCAPE;
-	}
-	else
-	{
-		mappingTableLevel4Special[44] = VK_ESCAPE;
-		mappingTableLevel4Special[45] = VK_TAB;
-		mappingTableLevel4Special[46] = VK_INSERT;
-		mappingTableLevel4Special[47] = VK_RETURN;
-	}
-	mappingTableLevel4Special[57] = '0';
+	initLevel4SpecialCases();
 }
 
 void toggleBypassMode()
@@ -319,11 +321,9 @@ void toggleBypassMode()
 	bypassMode = !bypassMode;
 
 	HINSTANCE hInstance = GetModuleHandle(NULL);
-	HICON icon;
-	if (bypassMode)
-		icon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_APPICON_DISABLED));
-	else
-		icon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_APPICON));
+	HICON icon = bypassMode
+		? LoadIcon(hInstance, MAKEINTRESOURCE(IDI_APPICON_DISABLED))
+		: LoadIcon(hInstance, MAKEINTRESOURCE(IDI_APPICON));
 
 	trayicon_change_icon(icon);
 	printf("%i bypass mode \n", bypassMode);
@@ -357,10 +357,8 @@ TCHAR mapScanCodeToChar(unsigned level, char in)
 DWORD dwFlagsFromKeyInfo(KBDLLHOOKSTRUCT keyInfo)
 {
 	DWORD dwFlags = 0;
-	if (keyInfo.flags & LLKHF_EXTENDED)
-		dwFlags |= KEYEVENTF_EXTENDEDKEY;
-	if (keyInfo.flags & LLKHF_UP)
-		dwFlags |= KEYEVENTF_KEYUP;
+	if (keyInfo.flags & LLKHF_EXTENDED) dwFlags |= KEYEVENTF_EXTENDEDKEY;
+	if (keyInfo.flags & LLKHF_UP) dwFlags |= KEYEVENTF_KEYUP;
 	return dwFlags;
 }
 
@@ -536,30 +534,30 @@ bool isShift(KBDLLHOOKSTRUCT keyInfo)
 bool isMod3(KBDLLHOOKSTRUCT keyInfo)
 {
 	return keyInfo.scanCode == scanCodeMod3L
-			|| keyInfo.scanCode == scanCodeMod3R;
+		|| keyInfo.scanCode == scanCodeMod3R;
 }
 
 bool isMod4(KBDLLHOOKSTRUCT keyInfo)
 {
 	return keyInfo.scanCode == scanCodeMod4L
-			|| keyInfo.vkCode == VK_RMENU;
+		|| keyInfo.vkCode == VK_RMENU;
 }
 
 bool isSystemKeyPressed()
 {
 	return ctrlLeftPressed || ctrlRightPressed
-			|| altLeftPressed
-			|| winLeftPressed || winRightPressed;
+		|| altLeftPressed
+		|| winLeftPressed || winRightPressed;
 }
 
 bool isLetter(TCHAR key)
 {
 	return (key >= 65 && key <= 90  // A-Z
-			 || key >= 97 && key <= 122  // a-z
-			 || key == L'ä' || key == L'ö'
-			 || key == L'ü' || key == L'ß'
-			 || key == L'Ä' || key == L'Ö'
-			 || key == L'Ü' || key == L'ẞ');
+		 || key >= 97 && key <= 122 // a-z
+		 || key == L'ä' || key == L'ö'
+		 || key == L'ü' || key == L'ß'
+		 || key == L'Ä' || key == L'Ö'
+		 || key == L'Ü' || key == L'ẞ');
 }
 
 void toggleShiftLock()
@@ -638,17 +636,20 @@ void logKeyEvent(char *desc, KBDLLHOOKSTRUCT keyInfo)
 			//keyName = MapVirtualKeyA(keyInfo.vkCode, MAPVK_VK_TO_CHAR);
 	}
 	char *shiftLockCapsLockInfo = shiftLockActive ? " [shift lock active]"
-	                              : (capsLockActive ? " [caps lock active]" : "");
+								: (capsLockActive ? " [caps lock active]" : "");
 	char *level4LockInfo = level4LockActive ? " [level4 lock active]" : "";
 	char *vkPacket = (desc=="injected" && keyInfo.vkCode == VK_PACKET) ? " (VK_PACKET)" : "";
-	printf("%-13s | sc:%03u vk:0x%02X flags:0x%02X extra:%d %s%s%s%s\n", desc, keyInfo.scanCode, keyInfo.vkCode,
-	       keyInfo.flags, keyInfo.dwExtraInfo, keyName, shiftLockCapsLockInfo, level4LockInfo, vkPacket);
+	printf(
+		"%-13s | sc:%03u vk:0x%02X flags:0x%02X extra:%d %s%s%s%s\n",
+		desc, keyInfo.scanCode, keyInfo.vkCode, keyInfo.flags, keyInfo.dwExtraInfo,
+		keyName, shiftLockCapsLockInfo, level4LockInfo, vkPacket
+	);
 }
 
 unsigned getLevel(ModState *modState) {
 	unsigned level = 1;
-	if (modState->shift != shiftLockActive)
-		// (modState.shift and no shiftLockActive) XOR (shiftLockActive and no modState.shift)
+
+	if (modState->shift != shiftLockActive) // (modState.shift) XOR (shiftLockActive)
 		level = 2;
 	if (modState->mod3)
 		level = (supportLevels5and6 && level == 2) ? 5 : 3;
@@ -908,9 +909,8 @@ LRESULT CALLBACK keyevent(int code, WPARAM wparam, LPARAM lparam)
 
 		bool callNext = updateStatesAndWriteKey(keyInfo, &modState, true);
 		if (!callNext) return -1;
-
-	}	else if (code == HC_ACTION && (wparam == WM_SYSKEYDOWN || wparam == WM_KEYDOWN)) {
-    printf("\n");
+	} else if (code == HC_ACTION && (wparam == WM_SYSKEYDOWN || wparam == WM_KEYDOWN)) {
+		printf("\n");
 		logKeyEvent("key down", keyInfo);
 
 		level3modLeftAndNoOtherKeyPressed = false;
@@ -979,7 +979,7 @@ bool fileExists(LPCSTR szPath)
 	DWORD dwAttrib = GetFileAttributesA(szPath);
 
 	return (dwAttrib != INVALID_FILE_ATTRIBUTES
-	        && !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
+	    && !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
 }
 
 int main(int argc, char *argv[])

--- a/src/main.c
+++ b/src/main.c
@@ -647,7 +647,7 @@ unsigned getLevel(struct ModState *modState) {
 /**
  * returns `true` if execution shall be continued, `false` otherwise
  **/
-boolean handleShiftKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, WPARAM wparam)
+boolean handleShiftKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, WPARAM wparam, bool ignoreShiftCapsLock)
 {
 	bool *pressedShift = keyInfo.vkCode == VK_RSHIFT ? &shiftRightPressed : &shiftLeftPressed;
 	bool *otherShift = keyInfo.vkCode == VK_RSHIFT ? &shiftLeftPressed : &shiftRightPressed;
@@ -656,7 +656,7 @@ boolean handleShiftKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, WPARA
 		modState->shift = false;
 		*pressedShift = false;
 
-		if (*otherShift) {
+		if (*otherShift && !ignoreShiftCapsLock) {
 			if (shiftLockEnabled) {
 				sendDownUp(VK_CAPITAL, 58, false);
 				toggleShiftLock();
@@ -868,7 +868,7 @@ LRESULT CALLBACK keyevent(int code, WPARAM wparam, LPARAM lparam)
 	}
 
 	if (code == HC_ACTION && isShift(keyInfo)) {
-		bool continueExecution = handleShiftKey(keyInfo, &modState, wparam);
+		bool continueExecution = handleShiftKey(keyInfo, &modState, wparam, bypassMode);
 		if (!continueExecution) return -1;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -15,10 +15,10 @@
 #include "resources.h"
 #include <io.h>
 
-struct ModState
+typedef struct ModState
 {
 	bool shift, mod3, mod4;
-};
+} ModState;
 
 HHOOK keyhook = NULL;
 #define APPNAME "neo-llkh"
@@ -631,7 +631,7 @@ void logKeyEvent(char *desc, KBDLLHOOKSTRUCT keyInfo)
 	       keyInfo.flags, keyInfo.dwExtraInfo, keyName, shiftLockCapsLockInfo, level4LockInfo, vkPacket);
 }
 
-unsigned getLevel(struct ModState *modState) {
+unsigned getLevel(ModState *modState) {
 	unsigned level = 1;
 	if (modState->shift != shiftLockActive)
 		// (modState.shift and no shiftLockActive) XOR (shiftLockActive and no modState.shift)
@@ -647,7 +647,7 @@ unsigned getLevel(struct ModState *modState) {
 /**
  * returns `true` if execution shall be continued, `false` otherwise
  **/
-boolean handleShiftKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, WPARAM wparam, bool ignoreShiftCapsLock)
+boolean handleShiftKey(KBDLLHOOKSTRUCT keyInfo, ModState *modState, WPARAM wparam, bool ignoreShiftCapsLock)
 {
 	bool *pressedShift = keyInfo.vkCode == VK_RSHIFT ? &shiftRightPressed : &shiftLeftPressed;
 	bool *otherShift = keyInfo.vkCode == VK_RSHIFT ? &shiftLeftPressed : &shiftRightPressed;
@@ -727,7 +727,7 @@ boolean handleSystemKey(KBDLLHOOKSTRUCT keyInfo, bool isKeyUp) {
 	return true;
 }
 
-void handleMod3Key(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKeyUp) {
+void handleMod3Key(KBDLLHOOKSTRUCT keyInfo, ModState *modState, bool isKeyUp) {
 	if (isKeyUp) {
 		if (keyInfo.scanCode == scanCodeMod3R) {
 			level3modRightPressed = false;
@@ -762,7 +762,7 @@ void handleMod3Key(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKe
 	}
 }
 
-void handleMod4Key(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKeyUp) {
+void handleMod4Key(KBDLLHOOKSTRUCT keyInfo, ModState *modState, bool isKeyUp) {
 	if (isKeyUp) {
 		if (keyInfo.scanCode == scanCodeMod4L) {
 			level4modLeftPressed = false;
@@ -806,7 +806,7 @@ void handleMod4Key(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKe
  * updates system key and layerLock states; writes key
  * returns `true` if next hook should be called, `false` otherwise
  **/
-bool updateStatesAndWriteKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKeyUp)
+bool updateStatesAndWriteKey(KBDLLHOOKSTRUCT keyInfo, ModState *modState, bool isKeyUp)
 {
 	bool continueExecution = handleSystemKey(keyInfo, isKeyUp);
 	if (!continueExecution) return false;
@@ -851,7 +851,7 @@ bool updateStatesAndWriteKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState,
 __declspec(dllexport)
 LRESULT CALLBACK keyevent(int code, WPARAM wparam, LPARAM lparam)
 {
-	static struct ModState modState = {false, false, false};
+	static ModState modState = {false, false, false};
 	KBDLLHOOKSTRUCT keyInfo;
 
 	if (
@@ -872,9 +872,8 @@ LRESULT CALLBACK keyevent(int code, WPARAM wparam, LPARAM lparam)
 		if (!continueExecution) return -1;
 	}
 
-
+	// Shift + Pause
 	if (code == HC_ACTION && wparam == WM_KEYDOWN && keyInfo.vkCode == VK_PAUSE && modState.shift) {
-		// Shift + Pause
 		toggleBypassMode();
 		return -1;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -536,30 +536,30 @@ bool isShift(KBDLLHOOKSTRUCT keyInfo)
 bool isMod3(KBDLLHOOKSTRUCT keyInfo)
 {
 	return keyInfo.scanCode == scanCodeMod3L
-		|| keyInfo.scanCode == scanCodeMod3R;
+	    || keyInfo.scanCode == scanCodeMod3R;
 }
 
 bool isMod4(KBDLLHOOKSTRUCT keyInfo)
 {
 	return keyInfo.scanCode == scanCodeMod4L
-		|| keyInfo.vkCode == VK_RMENU;
+	    || keyInfo.vkCode == VK_RMENU;
 }
 
 bool isSystemKeyPressed()
 {
 	return ctrlLeftPressed || ctrlRightPressed
-		|| altLeftPressed
-		|| winLeftPressed || winRightPressed;
+	    || altLeftPressed
+	    || winLeftPressed || winRightPressed;
 }
 
 bool isLetter(TCHAR key)
 {
 	return (key >= 65 && key <= 90  // A-Z
-		 || key >= 97 && key <= 122 // a-z
-		 || key == L'ä' || key == L'ö'
-		 || key == L'ü' || key == L'ß'
-		 || key == L'Ä' || key == L'Ö'
-		 || key == L'Ü' || key == L'ẞ');
+	     || key >= 97 && key <= 122 // a-z
+	     || key == L'ä' || key == L'ö'
+	     || key == L'ü' || key == L'ß'
+	     || key == L'Ä' || key == L'Ö'
+	     || key == L'Ü' || key == L'ẞ');
 }
 
 void toggleShiftLock()
@@ -638,7 +638,7 @@ void logKeyEvent(char *desc, KBDLLHOOKSTRUCT keyInfo)
 			//keyName = MapVirtualKeyA(keyInfo.vkCode, MAPVK_VK_TO_CHAR);
 	}
 	char *shiftLockCapsLockInfo = shiftLockActive ? " [shift lock active]"
-								: (capsLockActive ? " [caps lock active]" : "");
+						: (capsLockActive ? " [caps lock active]" : "");
 	char *level4LockInfo = level4LockActive ? " [level4 lock active]" : "";
 	char *vkPacket = (desc=="injected" && keyInfo.vkCode == VK_PACKET) ? " (VK_PACKET)" : "";
 	printf(

--- a/src/main.c
+++ b/src/main.c
@@ -356,25 +356,17 @@ void sendChar(TCHAR key, KBDLLHOOKSTRUCT keyInfo)
 			alt = false;
 		}
 
-		if (altgr)
-			keybd_event(VK_RMENU, 0, 0, 0);
-		if (ctrl)
-			keybd_event(VK_CONTROL, 0, 0, 0);
-		if (alt)
-			keybd_event(VK_MENU, 0, 0, 0); // ALT
-		if (shift)
-			keybd_event(VK_SHIFT, 0, 0, 0);
+		if (altgr) keybd_event(VK_RMENU, 0, 0, 0);
+		if (ctrl) keybd_event(VK_CONTROL, 0, 0, 0);
+		if (alt) keybd_event(VK_MENU, 0, 0, 0); // ALT
+		if (shift) keybd_event(VK_SHIFT, 0, 0, 0);
 
 		keybd_event(keyInfo.vkCode, keyInfo.scanCode, dwFlagsFromKeyInfo(keyInfo), keyInfo.dwExtraInfo);
 
-		if (altgr)
-			keybd_event(VK_RMENU, 0, KEYEVENTF_KEYUP, 0);
-		if (ctrl)
-			keybd_event(VK_CONTROL, 0, KEYEVENTF_KEYUP, 0);
-		if (alt)
-			keybd_event(VK_MENU, 0, KEYEVENTF_KEYUP, 0); // ALT
-		if (shift)
-			keybd_event(VK_SHIFT, 0, KEYEVENTF_KEYUP, 0);
+		if (altgr) keybd_event(VK_RMENU, 0, KEYEVENTF_KEYUP, 0);
+		if (ctrl) keybd_event(VK_CONTROL, 0, KEYEVENTF_KEYUP, 0);
+		if (alt) keybd_event(VK_MENU, 0, KEYEVENTF_KEYUP, 0); // ALT
+		if (shift) keybd_event(VK_SHIFT, 0, KEYEVENTF_KEYUP, 0);
 	}
 }
 
@@ -515,30 +507,30 @@ bool isShift(KBDLLHOOKSTRUCT keyInfo)
 bool isMod3(KBDLLHOOKSTRUCT keyInfo)
 {
 	return keyInfo.scanCode == scanCodeMod3L
-	    || keyInfo.scanCode == scanCodeMod3R;
+			|| keyInfo.scanCode == scanCodeMod3R;
 }
 
 bool isMod4(KBDLLHOOKSTRUCT keyInfo)
 {
 	return keyInfo.scanCode == scanCodeMod4L
-	    || keyInfo.vkCode == VK_RMENU;
+			|| keyInfo.vkCode == VK_RMENU;
 }
 
 bool isSystemKeyPressed()
 {
 	return ctrlLeftPressed || ctrlRightPressed
-	    || altLeftPressed
-	    || winLeftPressed || winRightPressed;
+			|| altLeftPressed
+			|| winLeftPressed || winRightPressed;
 }
 
 bool isLetter(TCHAR key)
 {
 	return (key >= 65 && key <= 90  // A-Z
-	        || key >= 97 && key <= 122  // a-z
-	        || key == L'ä' || key == L'ö'
-	        || key == L'ü' || key == L'ß'
-	        || key == L'Ä' || key == L'Ö'
-	        || key == L'Ü' || key == L'ẞ');
+			 || key >= 97 && key <= 122  // a-z
+			 || key == L'ä' || key == L'ö'
+			 || key == L'ü' || key == L'ß'
+			 || key == L'Ä' || key == L'Ö'
+			 || key == L'Ü' || key == L'ẞ');
 }
 
 void logKeyEvent(char *desc, KBDLLHOOKSTRUCT keyInfo)
@@ -818,8 +810,7 @@ void handleMod4Key(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKe
 bool updateStatesAndWriteKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKeyUp)
 {
 	bool continueExecution = handleSystemKey(keyInfo, isKeyUp);
-	if (!continueExecution)
-		return false;
+	if (!continueExecution) return false;
 
 	unsigned level = getLevel(modState);
 

--- a/src/main.c
+++ b/src/main.c
@@ -625,6 +625,10 @@ unsigned getLevel(struct ModState *modState) {
 	return level;
 }
 
+bool handleMod3Key() {
+
+}
+
 /**
  * updates system key and layerLock states; writes key
  * returns `true` if next hook should be called, `false` otherwise
@@ -704,13 +708,13 @@ bool updateAndWriteKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool 
 			return false;
 		} else {
 			if (keyInfo.scanCode == scanCodeMod3R) {
-				level3modRightPressed = true;
+				level3modRightPressed = newStateValue;
 				if (mod3RAsReturn)
-					level3modRightAndNoOtherKeyPressed = true;
+					level3modRightAndNoOtherKeyPressed = newStateValue;
 			} else { // VK_CAPITAL (CapsLock)
-				level3modLeftPressed = true;
+				level3modLeftPressed = newStateValue;
 				if (capsLockAsEscape)
-					level3modLeftAndNoOtherKeyPressed = true;
+					level3modLeftAndNoOtherKeyPressed = newStateValue;
 			}
 			modState->mod3 = level3modLeftPressed | level3modRightPressed;
 			return false;
@@ -724,10 +728,8 @@ bool updateAndWriteKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool 
 					level4LockActive = !level4LockActive;
 					printf("Level4 lock %s!\n", level4LockActive ? "activated" : "deactivated");
 				} else if (mod4LAsTab && level4modLeftAndNoOtherKeyPressed) {
-					// release Mod4_L
-					keybd_event(keyInfo.vkCode, 0, dwFlags, 0);
-					// send Tab
-					keybd_event(VK_TAB, 0, dwFlags | KEYEVENTF_EXTENDEDKEY, 0);
+					keybd_event(keyInfo.vkCode, 0, dwFlags, 0); // release Mod4_L
+					keybd_event(VK_TAB, 0, dwFlags | KEYEVENTF_EXTENDEDKEY, 0); // send Tab
 					level4modLeftAndNoOtherKeyPressed = newStateValue;
 					modState->mod4 = level4modLeftPressed | level4modRightPressed;
 					return false;
@@ -742,15 +744,12 @@ bool updateAndWriteKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool 
 			modState->mod4 = level4modLeftPressed | level4modRightPressed;
 			return false;
 		} else {
-			if (keyInfo.scanCode == scanCodeMod4L)
-			{
-				level4modLeftPressed = true;
+			if (keyInfo.scanCode == scanCodeMod4L) {
+				level4modLeftPressed = newStateValue;
 				if (mod4LAsTab)
 					level4modLeftAndNoOtherKeyPressed = !(level4modRightPressed || level3modLeftPressed || level3modRightPressed);
-			}
-			else
-			{ // scanCodeMod4R
-				level4modRightPressed = true;
+			} else { // scanCodeMod4R
+				level4modRightPressed = newStateValue;
 				/* ALTGR triggers two keys: LCONTROL and RMENU
 				   we don't want to have any of those two here effective but return -1 seems
 				   to change nothing, so we simply send keyup here.  */

--- a/src/main.c
+++ b/src/main.c
@@ -59,7 +59,6 @@ bool mod4LAsTab = false;             // if true, hitting Mod4L alone sends Tab
  * True if no mapping should be done
  */
 bool bypassMode = false;
-extern void toggleBypassMode();
 
 /**
  * States of some keys and shift lock.
@@ -313,6 +312,21 @@ void initLayout()
 		mappingTableLevel4Special[47] = VK_RETURN;
 	}
 	mappingTableLevel4Special[57] = '0';
+}
+
+void toggleBypassMode()
+{
+	bypassMode = !bypassMode;
+
+	HINSTANCE hInstance = GetModuleHandle(NULL);
+	HICON icon;
+	if (bypassMode)
+		icon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_APPICON_DISABLED));
+	else
+		icon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_APPICON));
+
+	trayicon_change_icon(icon);
+	printf("%i bypass mode \n", bypassMode);
 }
 
 /**
@@ -821,7 +835,6 @@ bool updateStatesAndWriteKey(KBDLLHOOKSTRUCT keyInfo, ModState *modState, bool i
 		return false;
 	} else if (keyInfo.flags == 1) {
 		return true;
-		// return CallNextHookEx(NULL, code, wparam, lparam);
 	} else if (level == 2 && handleLayer2SpecialCases(keyInfo)) {
 		return false;
 	} else if (level == 3 && handleLayer3SpecialCases(keyInfo)) {
@@ -959,21 +972,6 @@ void exitApplication()
 {
 	trayicon_remove();
 	PostQuitMessage(0);
-}
-
-void toggleBypassMode()
-{
-	bypassMode = !bypassMode;
-
-	HINSTANCE hInstance = GetModuleHandle(NULL);
-	HICON icon;
-	if (bypassMode)
-		icon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_APPICON_DISABLED));
-	else
-		icon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_APPICON));
-
-	trayicon_change_icon(icon);
-	printf("%i bypass mode \n", bypassMode);
 }
 
 bool fileExists(LPCSTR szPath)

--- a/src/main.c
+++ b/src/main.c
@@ -815,7 +815,7 @@ void handleMod4Key(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKe
  * updates system key and layerLock states; writes key
  * returns `true` if next hook should be called, `false` otherwise
  **/
-bool updateAndWriteKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKeyUp)
+bool updateStatesAndWriteKey(KBDLLHOOKSTRUCT keyInfo, struct ModState *modState, bool isKeyUp)
 {
 	bool continueExecution = handleSystemKey(keyInfo, isKeyUp);
 	if (!continueExecution)
@@ -896,7 +896,7 @@ LRESULT CALLBACK keyevent(int code, WPARAM wparam, LPARAM lparam)
 	if (code == HC_ACTION && (wparam == WM_SYSKEYUP || wparam == WM_KEYUP)) {
 		logKeyEvent("key up", keyInfo);
 
-		bool callNext = updateAndWriteKey(keyInfo, &modState, true);
+		bool callNext = updateStatesAndWriteKey(keyInfo, &modState, true);
 		if (!callNext) return -1;
 
 	}	else if (code == HC_ACTION && (wparam == WM_SYSKEYDOWN || wparam == WM_KEYDOWN)) {
@@ -907,7 +907,7 @@ LRESULT CALLBACK keyevent(int code, WPARAM wparam, LPARAM lparam)
 		level3modRightAndNoOtherKeyPressed = false;
 		level4modLeftAndNoOtherKeyPressed = false;
 
-		bool callNext = updateAndWriteKey(keyInfo, &modState, false);
+		bool callNext = updateStatesAndWriteKey(keyInfo, &modState, false);
 		if (!callNext) return -1;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -95,7 +95,7 @@ TCHAR mappingTableLevel3[LEN];
 TCHAR mappingTableLevel4[LEN];
 TCHAR mappingTableLevel5[LEN];
 TCHAR mappingTableLevel6[LEN];
-
+CHAR mappingTableLevel4Special[LEN];
 
 void SetStdOutToNewConsole()
 {
@@ -273,6 +273,46 @@ void initLayout()
 	}
 
 	mappingTableLevel2[8] = 0x20AC;  // €
+
+	// level4 special cases
+	for (int i = 0; i < LEN; i++)
+		mappingTableLevel4Special[i] = 0;
+
+	mappingTableLevel4Special[16] = VK_PRIOR;
+	if (strcmp(layout, "kou") == 0 || strcmp(layout, "vou") == 0)
+	{
+		mappingTableLevel4Special[17] = VK_NEXT;
+		mappingTableLevel4Special[18] = VK_UP;
+		mappingTableLevel4Special[19] = VK_BACK;
+		mappingTableLevel4Special[20] = VK_DELETE;
+	}
+	else
+	{
+		mappingTableLevel4Special[17] = VK_BACK;
+		mappingTableLevel4Special[18] = VK_UP;
+		mappingTableLevel4Special[19] = VK_DELETE;
+		mappingTableLevel4Special[20] = VK_NEXT;
+	}
+	mappingTableLevel4Special[30] = VK_HOME;
+	mappingTableLevel4Special[31] = VK_LEFT;
+	mappingTableLevel4Special[32] = VK_DOWN;
+	mappingTableLevel4Special[33] = VK_RIGHT;
+	mappingTableLevel4Special[34] = VK_END;
+	if (strcmp(layout, "kou") == 0 || strcmp(layout, "vou") == 0)
+	{
+		mappingTableLevel4Special[44] = VK_INSERT;
+		mappingTableLevel4Special[45] = VK_TAB;
+		mappingTableLevel4Special[46] = VK_RETURN;
+		mappingTableLevel4Special[47] = VK_ESCAPE;
+	}
+	else
+	{
+		mappingTableLevel4Special[44] = VK_ESCAPE;
+		mappingTableLevel4Special[45] = VK_TAB;
+		mappingTableLevel4Special[46] = VK_INSERT;
+		mappingTableLevel4Special[47] = VK_RETURN;
+	}
+	mappingTableLevel4Special[57] = '0';
 }
 
 /**
@@ -449,48 +489,15 @@ bool handleLayer4SpecialCases(KBDLLHOOKSTRUCT keyInfo)
 	// A second level 4 mapping table for special (non-unicode) keys.
 	// Maybe this could be included in the global TCHAR mapping table or level 4!?
 	BYTE bScan = 0;
-	CHAR mappingTable[LEN];
-	for (int i = 0; i < LEN; i++)
-		mappingTable[i] = 0;
 
-	mappingTable[16] = VK_PRIOR;
-	if (strcmp(layout, "kou") == 0 || strcmp(layout, "vou") == 0) {
-		mappingTable[17] = VK_NEXT;
-		mappingTable[18] = VK_UP;
-		mappingTable[19] = VK_BACK;
-		mappingTable[20] = VK_DELETE;
-	} else {
-		mappingTable[17] = VK_BACK;
-		mappingTable[18] = VK_UP;
-		mappingTable[19] = VK_DELETE;
-		mappingTable[20] = VK_NEXT;
-	}
-	mappingTable[30] = VK_HOME;
-	mappingTable[31] = VK_LEFT;
-	mappingTable[32] = VK_DOWN;
-	mappingTable[33] = VK_RIGHT;
-	mappingTable[34] = VK_END;
-	if (strcmp(layout, "kou") == 0 || strcmp(layout, "vou") == 0) {
-		mappingTable[44] = VK_INSERT;
-		mappingTable[45] = VK_TAB;
-		mappingTable[46] = VK_RETURN;
-		mappingTable[47] = VK_ESCAPE;
-	} else {
-		mappingTable[44] = VK_ESCAPE;
-		mappingTable[45] = VK_TAB;
-		mappingTable[46] = VK_INSERT;
-		mappingTable[47] = VK_RETURN;
-	}
-	mappingTable[57] = '0';
-
-	if (mappingTable[keyInfo.scanCode] != 0) {
-		if (mappingTable[keyInfo.scanCode] == VK_RETURN)
+	if (mappingTableLevel4Special[keyInfo.scanCode] != 0) {
+		if (mappingTableLevel4Special[keyInfo.scanCode] == VK_RETURN)
 			bScan = 0x1c;
-		else if (mappingTable[keyInfo.scanCode] == VK_INSERT)
+		else if (mappingTableLevel4Special[keyInfo.scanCode] == VK_INSERT)
 			bScan = 0x52;
 
 		// extended flag (bit 0) is necessary for selecting text with shift + arrow
-		keybd_event(mappingTable[keyInfo.scanCode], bScan, dwFlagsFromKeyInfo(keyInfo) | KEYEVENTF_EXTENDEDKEY, 0);
+		keybd_event(mappingTableLevel4Special[keyInfo.scanCode], bScan, dwFlagsFromKeyInfo(keyInfo) | KEYEVENTF_EXTENDEDKEY, 0);
 
 		return true;
 	}

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -1,10 +1,10 @@
 [Settings]
 # Layout: neo, adnw, adnwzjf, bone, koy, kou, vou, qwertz
-layout=neo
+layout=kou
 
-# use quote/ä as right level 3 modifier
-# ä-Taste als rechten Ebene3-Modifier verwenden
-symmetricalLevel3Modifiers=0
+# use quote/ï¿½ as right level 3 modifier
+# ï¿½-Taste als rechten Ebene3-Modifier verwenden
+symmetricalLevel3Modifiers=1
 
 # use Return as right level 3 modifier
 # Enter-Taste als rechten Ebene3-Modifier verwenden
@@ -16,7 +16,7 @@ tabKeyAsMod4L=0
 
 # enable caps lock (activate by pressing both shift keys)
 # Caps-Lock verwenden (aktivieren mit beiden Shift-Tasten gleichzeitig)
-capsLockEnabled=0
+capsLockEnabled=1
 
 # enable shift lock (activate by pressing both shift keys)
 # Shift-Lock verwenden (aktivieren mit beiden Shift-Tasten gleichzeitig)
@@ -24,11 +24,11 @@ shiftLockEnabled=0
 
 # enable level4 lock (activate by pressing both mod4 keys, experimental)
 # Ebene-4-Lock verwenden (aktivieren mit beiden Mod4-Tasten gleichzeitig, experimentell)
-level4LockEnabled=0
+level4LockEnabled=1
 
 # use QWERTZ for shortcuts
-# QWERTZ für Shortcuts verwenden
-qwertzForShortcuts=0
+# QWERTZ fï¿½r Shortcuts verwenden
+qwertzForShortcuts=1
 
 # swap left ctrl and left alt key
 # linke Strg- und linke Alt-Taste vertauschen
@@ -40,8 +40,8 @@ swapLeftCtrlAndLeftAlt=0
 swapLeftCtrlLeftAltAndLeftWin=0
 
 # support levels 5 and 6 (experimental)
-# Unterstützung der Ebenen 5 und 6 (experimentell)
-supportLevels5and6=0
+# Unterstï¿½tzung der Ebenen 5 und 6 (experimentell)
+supportLevels5and6=1
 
 # CapsLock key acts as Escape when hit alone (experimental)
 # CapsLock-Taste sendet Escape, wenn sie alleine angeschlagen wird (experimentell)

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -4,7 +4,7 @@ layout=kou
 
 # use quote/� as right level 3 modifier
 # �-Taste als rechten Ebene3-Modifier verwenden
-symmetricalLevel3Modifiers=1
+symmetricalLevel3Modifiers=0
 
 # use Return as right level 3 modifier
 # Enter-Taste als rechten Ebene3-Modifier verwenden
@@ -16,7 +16,7 @@ tabKeyAsMod4L=0
 
 # enable caps lock (activate by pressing both shift keys)
 # Caps-Lock verwenden (aktivieren mit beiden Shift-Tasten gleichzeitig)
-capsLockEnabled=1
+capsLockEnabled=0
 
 # enable shift lock (activate by pressing both shift keys)
 # Shift-Lock verwenden (aktivieren mit beiden Shift-Tasten gleichzeitig)
@@ -24,11 +24,11 @@ shiftLockEnabled=0
 
 # enable level4 lock (activate by pressing both mod4 keys, experimental)
 # Ebene-4-Lock verwenden (aktivieren mit beiden Mod4-Tasten gleichzeitig, experimentell)
-level4LockEnabled=1
+level4LockEnabled=0
 
 # use QWERTZ for shortcuts
 # QWERTZ f�r Shortcuts verwenden
-qwertzForShortcuts=1
+qwertzForShortcuts=0
 
 # swap left ctrl and left alt key
 # linke Strg- und linke Alt-Taste vertauschen
@@ -41,7 +41,7 @@ swapLeftCtrlLeftAltAndLeftWin=0
 
 # support levels 5 and 6 (experimental)
 # Unterst�tzung der Ebenen 5 und 6 (experimentell)
-supportLevels5and6=1
+supportLevels5and6=0
 
 # CapsLock key acts as Escape when hit alone (experimental)
 # CapsLock-Taste sendet Escape, wenn sie alleine angeschlagen wird (experimentell)

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -4,7 +4,7 @@ layout=kou
 
 # use quote/� as right level 3 modifier
 # �-Taste als rechten Ebene3-Modifier verwenden
-symmetricalLevel3Modifiers=0
+symmetricalLevel3Modifiers=1
 
 # use Return as right level 3 modifier
 # Enter-Taste als rechten Ebene3-Modifier verwenden
@@ -16,7 +16,7 @@ tabKeyAsMod4L=0
 
 # enable caps lock (activate by pressing both shift keys)
 # Caps-Lock verwenden (aktivieren mit beiden Shift-Tasten gleichzeitig)
-capsLockEnabled=0
+capsLockEnabled=1
 
 # enable shift lock (activate by pressing both shift keys)
 # Shift-Lock verwenden (aktivieren mit beiden Shift-Tasten gleichzeitig)
@@ -24,11 +24,11 @@ shiftLockEnabled=0
 
 # enable level4 lock (activate by pressing both mod4 keys, experimental)
 # Ebene-4-Lock verwenden (aktivieren mit beiden Mod4-Tasten gleichzeitig, experimentell)
-level4LockEnabled=0
+level4LockEnabled=1
 
 # use QWERTZ for shortcuts
 # QWERTZ f�r Shortcuts verwenden
-qwertzForShortcuts=0
+qwertzForShortcuts=1
 
 # swap left ctrl and left alt key
 # linke Strg- und linke Alt-Taste vertauschen
@@ -37,23 +37,23 @@ swapLeftCtrlAndLeftAlt=0
 # swap left ctrl, left alt and left windows key
 # linke Strg-, linke Alt- und linke Windows-Taste vertauschen
 # -> Win, Alt, Ctrl
-swapLeftCtrlLeftAltAndLeftWin=0
+swapLeftCtrlLeftAltAndLeftWin=1
 
 # support levels 5 and 6 (experimental)
 # Unterst�tzung der Ebenen 5 und 6 (experimentell)
-supportLevels5and6=0
+supportLevels5and6=1
 
 # CapsLock key acts as Escape when hit alone (experimental)
 # CapsLock-Taste sendet Escape, wenn sie alleine angeschlagen wird (experimentell)
-capsLockAsEscape=0
+capsLockAsEscape=1
 
 # the right level 3 modifier acts as Return when hit alone (experimental)
 # der rechte Ebene3-Modifier sendet Return, wenn er alleine angeschlagen wird (experimentell)
-mod3RAsReturn=0
+mod3RAsReturn=1
 
 # the left level 4 modifier acts as Tab when hit alone (experimental)
 # der linke Ebene4-Modifier sendet Tab, wenn er alleine angeschlagen wird (experimentell)
-mod4LAsTab=0
+mod4LAsTab=1
 
 # show debug output in a separate console window
 # Debug-Ausgabe in einem separaten Konsolen-Fenster anzeigen

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -3,7 +3,7 @@
 layout=neo
 
 # use quote/ä as right level 3 modifier
-# �-Taste als rechten Ebene3-Modifier verwenden
+# ä-Taste als rechten Ebene3-Modifier verwenden
 symmetricalLevel3Modifiers=0
 
 # use Return as right level 3 modifier

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -1,10 +1,10 @@
 [Settings]
 # Layout: neo, adnw, adnwzjf, bone, koy, kou, vou, qwertz
-layout=kou
+layout=neo
 
-# use quote/� as right level 3 modifier
+# use quote/ä as right level 3 modifier
 # �-Taste als rechten Ebene3-Modifier verwenden
-symmetricalLevel3Modifiers=1
+symmetricalLevel3Modifiers=0
 
 # use Return as right level 3 modifier
 # Enter-Taste als rechten Ebene3-Modifier verwenden
@@ -16,7 +16,7 @@ tabKeyAsMod4L=0
 
 # enable caps lock (activate by pressing both shift keys)
 # Caps-Lock verwenden (aktivieren mit beiden Shift-Tasten gleichzeitig)
-capsLockEnabled=1
+capsLockEnabled=0
 
 # enable shift lock (activate by pressing both shift keys)
 # Shift-Lock verwenden (aktivieren mit beiden Shift-Tasten gleichzeitig)
@@ -24,11 +24,11 @@ shiftLockEnabled=0
 
 # enable level4 lock (activate by pressing both mod4 keys, experimental)
 # Ebene-4-Lock verwenden (aktivieren mit beiden Mod4-Tasten gleichzeitig, experimentell)
-level4LockEnabled=1
+level4LockEnabled=0
 
 # use QWERTZ for shortcuts
-# QWERTZ f�r Shortcuts verwenden
-qwertzForShortcuts=1
+# QWERTZ für Shortcuts verwenden
+qwertzForShortcuts=0
 
 # swap left ctrl and left alt key
 # linke Strg- und linke Alt-Taste vertauschen
@@ -37,23 +37,23 @@ swapLeftCtrlAndLeftAlt=0
 # swap left ctrl, left alt and left windows key
 # linke Strg-, linke Alt- und linke Windows-Taste vertauschen
 # -> Win, Alt, Ctrl
-swapLeftCtrlLeftAltAndLeftWin=1
+swapLeftCtrlLeftAltAndLeftWin=0
 
 # support levels 5 and 6 (experimental)
-# Unterst�tzung der Ebenen 5 und 6 (experimentell)
-supportLevels5and6=1
+# Unterstützung der Ebenen 5 und 6 (experimentell)
+supportLevels5and6=0
 
 # CapsLock key acts as Escape when hit alone (experimental)
 # CapsLock-Taste sendet Escape, wenn sie alleine angeschlagen wird (experimentell)
-capsLockAsEscape=1
+capsLockAsEscape=0
 
 # the right level 3 modifier acts as Return when hit alone (experimental)
 # der rechte Ebene3-Modifier sendet Return, wenn er alleine angeschlagen wird (experimentell)
-mod3RAsReturn=1
+mod3RAsReturn=0
 
 # the left level 4 modifier acts as Tab when hit alone (experimental)
 # der linke Ebene4-Modifier sendet Tab, wenn er alleine angeschlagen wird (experimentell)
-mod4LAsTab=1
+mod4LAsTab=0
 
 # show debug output in a separate console window
 # Debug-Ausgabe in einem separaten Konsolen-Fenster anzeigen


### PR DESCRIPTION
I had a go at fixing the things that didn't work properly and bothered me (and others, it seems) and actually managed to do so. These are the changes summarized:

1. Added handling of `keyUp` events (and combined it with `keyDown`)
    * Fixes all (from my testing) issues with Chrome and VSCode
    * Closes #23, closes #17, closes #13 (and would close #8 if it was still open)
1. Refactored handling of key events and updating of states by moving many things to their own functions
1. Added `scanCode` to manually sent key events
1. Improved (imo) formatting of log messages to this:
    ```
    key down      | sc:050 vk:0x4D flags:0x00 extra:0 (M)
     mapped       | sc:050 M->m [0x006D] (level 1)
    injected down | sc:050 vk:0x4D flags:0x10 extra:0 (M)
    key up        | sc:050 vk:0x4D flags:0x80 extra:0 (M)
     mapped       | sc:050 M->m [0x006D] (level 1)
    injected up   | sc:050 vk:0x4D flags:0x90 extra:0 (M)
    ```
1. Added synchronization of `ShiftLock` and `CapsLock` with windows `CapsLock` state.
    * This is achieved by sending an actual `CapsLock` keypress when toggling `ShiftLock` or `CapsLock`
    * This is also done during `bypassMode`, so when `bypassMode=true` and `CapsLock` is pressed, it will also be enabled when switching back to `bypassMode=false`
    * This now also toggles the keyboard indicator correctly for me
1. Moved initialization of layer 4 special cases to `initLayout`

I have been using this for 2 weeks now and haven't noticed any problems in daily use (though while gaming I always had it disabled because the modifier keys don't behave how they'd need to for those programs - for me at least). 