### PR TITLE
Bugfix: Alt-Release vor Ctrl-Release

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -835,8 +835,8 @@ void sendChar(TCHAR key, KBDLLHOOKSTRUCT keyInfo) {
 		keybd_event(keyInfo.vkCode, keyInfo.scanCode, dwFlagsFromKeyInfo(keyInfo), keyInfo.dwExtraInfo);
 
 		if (altgr) sendUp(VK_RMENU, 56, true);
-		if (ctrl) sendUp(VK_CONTROL, 29, false);
 		if (alt) sendUp(VK_MENU, 56, false); // ALT
+		if (ctrl) sendUp(VK_CONTROL, 29, false);
 		if (shift) sendUp(VK_SHIFT, 42, false);
 	}
 }


### PR DESCRIPTION
Durch das Ändern der Reihenfolge wird verhindert, dass durch das (injizierte) Loslassen der Alt-Taste Menüs fokussiert werden.

Relevant bei mir für ä, ö, ü und ß auf QWERTY und {, [, ] und } auf QWERTZ in VSCode.

Mit QWERTZ und QWERTY meine ich das Keyboard-Layout, das bei Windows eingerichtet ist.